### PR TITLE
[INT-528] Gate n8n style agent on /style-agent/config + add targets dropdown

### DIFF
--- a/nodes/Markupai/Markupai.api.types.ts
+++ b/nodes/Markupai/Markupai.api.types.ts
@@ -73,3 +73,18 @@ export interface IssueCounts {
   medium: number;
   low: number;
 }
+
+export type StyleAgentMode = "enabled" | "enabled_terminology" | "disabled";
+
+export interface OrganizationConfigResponse {
+  is_acrolinx_classic: boolean;
+  style_agent: StyleAgentMode;
+  style_agent_numeric_scoring: boolean;
+}
+
+export interface StyleAgentTarget {
+  id: string;
+  display_name: string;
+  is_default: boolean;
+  enabled: boolean;
+}

--- a/nodes/Markupai/Markupai.node.ts
+++ b/nodes/Markupai/Markupai.node.ts
@@ -8,11 +8,13 @@ import {
 import { MARKUPAI_API_CREDENTIAL_NAME } from "../../credentials/MarkupAiApi.credentials";
 import { listAllAgents } from "./utils/agents.api.utils";
 import { DOMAIN_IDS_AGENT_IDS, STYLE_OPTION_AGENT_IDS } from "./utils/agent.input.coverage";
-import { loadAgents, loadTerminologyDomains } from "./utils/load.options";
+import { loadAgents, loadStyleAgentTargets, loadTerminologyDomains } from "./utils/load.options";
 import { processMarkupaiItem } from "./utils/process.item";
+import { assertStyleAgentEnabled, getStyleAgentConfig } from "./utils/style_agent_api";
 
 const LOAD_AGENTS = "loadAgents" as const;
 const LOAD_TERMINOLOGY_DOMAINS = "loadTerminologyDomains" as const;
+const LOAD_STYLE_AGENT_TARGETS = "loadStyleAgentTargets" as const;
 
 export class Markupai implements INodeType {
   description: INodeTypeDescription = {
@@ -119,11 +121,16 @@ export class Markupai implements INodeType {
         },
       },
       {
-        displayName: "Target ID",
+        displayName: "Target",
         name: "targetId",
-        type: "string",
+        type: "options",
+        options: [],
         default: "",
-        description: "Language-service target ID for style checks",
+        description:
+          "Configured style agent target. Content profile is auto-detected by Markup AI.",
+        typeOptions: {
+          loadOptionsMethod: LOAD_STYLE_AGENT_TARGETS,
+        },
         displayOptions: {
           show: {
             resource: ["agent"],
@@ -206,12 +213,17 @@ export class Markupai implements INodeType {
     loadOptions: {
       [LOAD_AGENTS]: loadAgents,
       [LOAD_TERMINOLOGY_DOMAINS]: loadTerminologyDomains,
+      [LOAD_STYLE_AGENT_TARGETS]: loadStyleAgentTargets,
     },
   };
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
     const items = this.getInputData();
     const returnData: INodeExecutionData[] = [];
+
+    const styleAgentConfig = await getStyleAgentConfig.call(this);
+    assertStyleAgentEnabled(styleAgentConfig);
+
     const allAgents = await listAllAgents.call(this);
 
     for (let i = 0; i < items.length; i++) {

--- a/nodes/Markupai/utils/load.options.ts
+++ b/nodes/Markupai/utils/load.options.ts
@@ -4,6 +4,7 @@ import type {
   INodePropertyOptions,
 } from "n8n-workflow";
 import { getBaseUrlString } from "../../../utils/common.utils";
+import { listStyleAgentTargets } from "./style_agent_api";
 import type {
   AgentListResult,
   TerminologyDomain,
@@ -140,4 +141,23 @@ export async function loadTerminologyDomains(
       value: domain.id,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function loadStyleAgentTargets(
+  this: ILoadOptionsFunctions,
+): Promise<INodePropertyOptions[]> {
+  const targets = await listStyleAgentTargets.call(this);
+
+  return targets
+    .map((target) => ({
+      name: target.display_name,
+      value: target.id,
+    }))
+    .sort((a, b) => {
+      const aIsDefault = targets.find((t) => t.id === a.value)?.is_default ?? false;
+      const bIsDefault = targets.find((t) => t.id === b.value)?.is_default ?? false;
+      if (aIsDefault && !bIsDefault) return -1;
+      if (!aIsDefault && bIsDefault) return 1;
+      return a.name.localeCompare(b.name);
+    });
 }

--- a/nodes/Markupai/utils/style_agent_api.ts
+++ b/nodes/Markupai/utils/style_agent_api.ts
@@ -1,0 +1,78 @@
+import type { IExecuteFunctions, IHttpRequestOptions, ILoadOptionsFunctions } from "n8n-workflow";
+import { getBaseUrl } from "./load.options";
+import type { OrganizationConfigResponse, StyleAgentTarget } from "../Markupai.api.types";
+
+const CONFIG_PATH = "style-agent/config";
+const TARGETS_PATH = "style-agent/targets";
+
+export const STYLE_AGENT_DISABLED_MESSAGE =
+  "Style Agent is not enabled for your organization. Contact Markup AI support to enable it.";
+
+const ENABLED_STYLE_AGENT_MODES: ReadonlySet<string> = new Set(["enabled", "enabled_terminology"]);
+
+type StyleAgentApiContext = IExecuteFunctions | ILoadOptionsFunctions;
+
+function buildApiUrl(baseUrl: URL, path: string): string {
+  const normalizedBaseUrl = new URL(
+    baseUrl.toString().endsWith("/") ? baseUrl.toString() : `${baseUrl.toString()}/`,
+  );
+  return new URL(path, normalizedBaseUrl).toString();
+}
+
+function stringifyResponseBody(body: unknown): string {
+  if (typeof body === "string") return body;
+  if (typeof body === "object" && body !== null) return JSON.stringify(body);
+  return String(body);
+}
+
+function assertSuccessStatus(
+  response: { statusCode: number; body: unknown },
+  errorPrefix: string,
+): void {
+  if (response.statusCode === 200) return;
+  throw new Error(`${errorPrefix}: ${stringifyResponseBody(response.body)}`);
+}
+
+async function getJson<T>(
+  context: StyleAgentApiContext,
+  path: string,
+  errorPrefix: string,
+): Promise<T> {
+  const requestOptions: IHttpRequestOptions = {
+    method: "GET",
+    url: buildApiUrl(getBaseUrl(), path),
+    returnFullResponse: true,
+  };
+  const response = (await context.helpers.httpRequestWithAuthentication.call(
+    context,
+    "markupaiApi",
+    requestOptions,
+  )) as { statusCode: number; body: unknown };
+  assertSuccessStatus(response, errorPrefix);
+  const bodyStr = typeof response.body === "string" ? response.body : JSON.stringify(response.body);
+  return JSON.parse(bodyStr) as T;
+}
+
+export async function getStyleAgentConfig(
+  this: StyleAgentApiContext,
+): Promise<OrganizationConfigResponse> {
+  return getJson<OrganizationConfigResponse>(this, CONFIG_PATH, "Error loading style agent config");
+}
+
+export function assertStyleAgentEnabled(config: OrganizationConfigResponse): void {
+  if (!ENABLED_STYLE_AGENT_MODES.has(config.style_agent)) {
+    throw new Error(STYLE_AGENT_DISABLED_MESSAGE);
+  }
+}
+
+export async function listStyleAgentTargets(
+  this: StyleAgentApiContext,
+): Promise<StyleAgentTarget[]> {
+  const targets = await getJson<StyleAgentTarget[] | null>(
+    this,
+    TARGETS_PATH,
+    "Error loading style agent targets",
+  );
+  if (!Array.isArray(targets)) return [];
+  return targets.filter((target) => target.enabled);
+}

--- a/test/nodes/Markupai.node.test.ts
+++ b/test/nodes/Markupai.node.test.ts
@@ -25,6 +25,7 @@ vi.mock("n8n-workflow", async () => {
 vi.mock("../../nodes/Markupai/utils/load.options", () => ({
   loadAgents: vi.fn(),
   loadTerminologyDomains: vi.fn(),
+  loadStyleAgentTargets: vi.fn(),
 }));
 
 vi.mock("../../nodes/Markupai/utils/agents.api.utils", () => ({
@@ -33,6 +34,20 @@ vi.mock("../../nodes/Markupai/utils/agents.api.utils", () => ({
     .fn()
     .mockResolvedValue([{ id: "ag_content_analysis", name: "Content Analysis" }]),
 }));
+
+vi.mock("../../nodes/Markupai/utils/style_agent_api", async () => {
+  const actual = await vi.importActual<typeof import("../../nodes/Markupai/utils/style_agent_api")>(
+    "../../nodes/Markupai/utils/style_agent_api",
+  );
+  return {
+    ...actual,
+    getStyleAgentConfig: vi.fn().mockResolvedValue({
+      is_acrolinx_classic: false,
+      style_agent: "enabled",
+      style_agent_numeric_scoring: false,
+    }),
+  };
+});
 
 const createRunResponse = () => ({
   workflow_id: "wf_123",
@@ -122,6 +137,10 @@ describe("Markupai", () => {
       expect(propertyNames).toContain("targetId");
       expect(propertyNames).toContain("contentProfileId");
 
+      const targetIdProp = properties.find((p) => p.name === "targetId");
+      expect(targetIdProp?.type).toBe("options");
+      expect(targetIdProp?.typeOptions?.loadOptionsMethod).toBe("loadStyleAgentTargets");
+
       const additionalOptionsProp = properties.find((p) => p.name === "additionalOptions");
       expect(additionalOptionsProp).toBeDefined();
       if (
@@ -161,9 +180,10 @@ describe("Markupai", () => {
   });
 
   describe("Methods", () => {
-    it("should have loadAgents and loadTerminologyDomains in loadOptions", () => {
+    it("should have loadAgents, loadTerminologyDomains, and loadStyleAgentTargets in loadOptions", () => {
       expect(markupai.methods.loadOptions.loadAgents).toBeDefined();
       expect(markupai.methods.loadOptions.loadTerminologyDomains).toBeDefined();
+      expect(markupai.methods.loadOptions.loadStyleAgentTargets).toBeDefined();
     });
   });
 
@@ -231,6 +251,33 @@ describe("Markupai", () => {
       await expect(
         markupai.execute.call(mockExecuteFunctions as IExecuteFunctions),
       ).rejects.toThrow();
+    });
+
+    it("should throw a friendly error when style agent is disabled", async () => {
+      const { getStyleAgentConfig } = await import("../../nodes/Markupai/utils/style_agent_api");
+      vi.mocked(getStyleAgentConfig).mockResolvedValueOnce({
+        is_acrolinx_classic: false,
+        style_agent: "disabled",
+        style_agent_numeric_scoring: false,
+      });
+
+      await expect(
+        markupai.execute.call(mockExecuteFunctions as IExecuteFunctions),
+      ).rejects.toThrow(
+        "Style Agent is not enabled for your organization. Contact Markup AI support to enable it.",
+      );
+    });
+
+    it("should call style agent config gate once per execute regardless of item count", async () => {
+      const { getStyleAgentConfig } = await import("../../nodes/Markupai/utils/style_agent_api");
+      vi.mocked(getStyleAgentConfig).mockClear();
+
+      const threeItems: INodeExecutionData[] = [{ json: {} }, { json: {} }, { json: {} }];
+      mockExecuteFunctions.getInputData = vi.fn().mockReturnValue(threeItems);
+
+      await markupai.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+      expect(vi.mocked(getStyleAgentConfig)).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/utils/load.options.test.ts
+++ b/test/utils/load.options.test.ts
@@ -3,6 +3,7 @@ import type { ILoadOptionsFunctions } from "n8n-workflow";
 import {
   getBaseUrl,
   loadAgents,
+  loadStyleAgentTargets,
   loadTerminologyDomains,
 } from "../../nodes/Markupai/utils/load.options";
 
@@ -242,6 +243,55 @@ describe("load.options", () => {
 
       await expect(loadTerminologyDomains.call(loadOptionsFunction)).rejects.toThrow(
         "Error loading terminology domains",
+      );
+    });
+  });
+
+  describe("loadStyleAgentTargets", () => {
+    const targetsResponse = [
+      { id: "tgt_main", display_name: "Main", is_default: true, enabled: true },
+      { id: "tgt_marketing", display_name: "Marketing", is_default: false, enabled: true },
+      { id: "tgt_dev", display_name: "Dev", is_default: false, enabled: true },
+      { id: "tgt_disabled", display_name: "Disabled SG", is_default: false, enabled: false },
+    ];
+
+    it("returns enabled targets with default first, then alphabetical", async () => {
+      const loadOptionsFunction = createMockLoadOptionsFunctions({
+        getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
+        helpers: {
+          httpRequestWithAuthentication: {
+            call: vi.fn().mockResolvedValue({
+              body: targetsResponse,
+              statusCode: 200,
+            }),
+          },
+        },
+      });
+
+      const result = await loadStyleAgentTargets.call(loadOptionsFunction);
+
+      expect(result).toEqual([
+        { name: "Main", value: "tgt_main" },
+        { name: "Dev", value: "tgt_dev" },
+        { name: "Marketing", value: "tgt_marketing" },
+      ]);
+    });
+
+    it("throws if the targets API returns an error status", async () => {
+      const loadOptionsFunction = createMockLoadOptionsFunctions({
+        getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
+        helpers: {
+          httpRequestWithAuthentication: {
+            call: vi.fn().mockResolvedValue({
+              body: { detail: "forbidden" },
+              statusCode: 403,
+            }),
+          },
+        },
+      });
+
+      await expect(loadStyleAgentTargets.call(loadOptionsFunction)).rejects.toThrow(
+        "Error loading style agent targets",
       );
     });
   });

--- a/test/utils/style_agent_api.test.ts
+++ b/test/utils/style_agent_api.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ILoadOptionsFunctions } from "n8n-workflow";
+import {
+  assertStyleAgentEnabled,
+  getStyleAgentConfig,
+  listStyleAgentTargets,
+  STYLE_AGENT_DISABLED_MESSAGE,
+} from "../../nodes/Markupai/utils/style_agent_api";
+import type {
+  OrganizationConfigResponse,
+  StyleAgentTarget,
+} from "../../nodes/Markupai/Markupai.api.types";
+
+function createMockContext(mockCall: ReturnType<typeof vi.fn>): ILoadOptionsFunctions {
+  return {
+    getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
+    helpers: {
+      httpRequestWithAuthentication: {
+        call: mockCall,
+      },
+    },
+  } as unknown as ILoadOptionsFunctions;
+}
+
+describe("style_agent_api", () => {
+  beforeEach(() => {
+    delete process.env.MARKUP_AI_BASE_URL;
+  });
+
+  describe("getStyleAgentConfig", () => {
+    it("returns the parsed org config on 200", async () => {
+      const config: OrganizationConfigResponse = {
+        is_acrolinx_classic: false,
+        style_agent: "enabled",
+        style_agent_numeric_scoring: true,
+      };
+      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: config });
+      const ctx = createMockContext(mockCall);
+
+      const result = await getStyleAgentConfig.call(ctx);
+
+      expect(result).toEqual(config);
+      expect(mockCall).toHaveBeenCalledWith(
+        ctx,
+        "markupaiApi",
+        expect.objectContaining({
+          method: "GET",
+          url: "https://api.markup.ai/style-agent/config",
+        }),
+      );
+    });
+
+    it("throws on non-200 status", async () => {
+      const mockCall = vi
+        .fn()
+        .mockResolvedValue({ statusCode: 500, body: { detail: "server boom" } });
+      const ctx = createMockContext(mockCall);
+
+      await expect(getStyleAgentConfig.call(ctx)).rejects.toThrow(
+        "Error loading style agent config",
+      );
+    });
+  });
+
+  describe("assertStyleAgentEnabled", () => {
+    it("passes when style_agent is enabled", () => {
+      expect(() => {
+        assertStyleAgentEnabled({
+          is_acrolinx_classic: false,
+          style_agent: "enabled",
+          style_agent_numeric_scoring: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("passes when style_agent is enabled_terminology", () => {
+      expect(() => {
+        assertStyleAgentEnabled({
+          is_acrolinx_classic: false,
+          style_agent: "enabled_terminology",
+          style_agent_numeric_scoring: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("throws the canonical disabled message when style_agent is disabled", () => {
+      expect(() => {
+        assertStyleAgentEnabled({
+          is_acrolinx_classic: false,
+          style_agent: "disabled",
+          style_agent_numeric_scoring: false,
+        });
+      }).toThrow(STYLE_AGENT_DISABLED_MESSAGE);
+    });
+  });
+
+  describe("listStyleAgentTargets", () => {
+    it("returns only enabled targets, parsed as an array", async () => {
+      const apiTargets: StyleAgentTarget[] = [
+        { id: "tgt_1", display_name: "Main", is_default: true, enabled: true },
+        { id: "tgt_2", display_name: "Disabled SG", is_default: false, enabled: false },
+        { id: "tgt_3", display_name: "Marketing", is_default: false, enabled: true },
+      ];
+      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: apiTargets });
+      const ctx = createMockContext(mockCall);
+
+      const result = await listStyleAgentTargets.call(ctx);
+
+      expect(result.map((t) => t.id)).toEqual(["tgt_1", "tgt_3"]);
+    });
+
+    it("returns empty array when API returns null body", async () => {
+      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: null });
+      const ctx = createMockContext(mockCall);
+
+      const result = await listStyleAgentTargets.call(ctx);
+
+      expect(result).toEqual([]);
+    });
+
+    it("throws on non-200 status", async () => {
+      const mockCall = vi
+        .fn()
+        .mockResolvedValue({ statusCode: 403, body: { detail: "forbidden" } });
+      const ctx = createMockContext(mockCall);
+
+      await expect(listStyleAgentTargets.call(ctx)).rejects.toThrow(
+        "Error loading style agent targets",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Mirror zapier's [INT-518](https://markup-ai.atlassian.net/browse/INT-518) / [zapier-app#225](https://github.com/markupai/zapier-app/pull/225) in n8n. First of three sequenced PRs aligning n8n with the latest Markup AI agentic API surface (next: report port, then doc-metadata + drift).

- Add `OrganizationConfigResponse` and `StyleAgentTarget` types.
- New `nodes/Markupai/utils/style_agent_api.ts` helper exporting `getStyleAgentConfig`, `assertStyleAgentEnabled`, `listStyleAgentTargets` — reuses zapier's canonical disabled-error message.
- New `loadStyleAgentTargets` dropdown loader (default target first, then alphabetical).
- Convert `Target ID` from a free-text input into an options dropdown backed by `GET /style-agent/targets`.
- `execute()` now fetches `/style-agent/config` once per run and rejects with the canonical message when `style_agent` is `disabled`.

`style_agent_numeric_scoring` is fetched but not yet consumed — that wires into [INT-529](https://markup-ai.atlassian.net/browse/INT-529) (report port).

JIRA: [INT-528](https://markup-ai.atlassian.net/browse/INT-528) (under epic [INT-131 n8n](https://markup-ai.atlassian.net/browse/INT-131))

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npm run type-check`
- [x] `npm test` — 97/97 tests pass (new style_agent_api.test.ts + loadStyleAgentTargets + gating cases)
- [x] `npm run build` — gulp + tsc clean
- [ ] Manual: load the node in a local n8n; verify `Target` is now a dropdown populated from `/style-agent/targets`, and the node fails fast against an org with `style_agent: "disabled"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INT-518]: https://markup-ai.atlassian.net/browse/INT-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-529]: https://markup-ai.atlassian.net/browse/INT-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-528]: https://markup-ai.atlassian.net/browse/INT-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ