### PR TITLE
[INT-530] Align n8n style agent inputs with AgentRunRequest schema

### DIFF
--- a/nodes/Markupai/Markupai.api.types.ts
+++ b/nodes/Markupai/Markupai.api.types.ts
@@ -51,20 +51,20 @@ export interface AgentRunRequest {
   domain_ids?: string[] | null;
   url?: string | null;
   document_name?: string | null;
-  org_name?: string | null;
+  document_ref?: string | null;
   target_id?: string | null;
-  content_profile_id?: string | null;
   webhook_url?: string | null;
 }
 
 export interface AgentRunResponse {
   workflow_id: string;
+  request_id?: string | null;
   status: WorkflowStatus;
+  document_ref?: string | null;
   result?: Record<string, unknown> | null;
   started_at: string;
   completed_at?: string | null;
   duration_seconds?: number | null;
-  error?: string | null;
 }
 
 export interface IssueCounts {

--- a/nodes/Markupai/Markupai.node.ts
+++ b/nodes/Markupai/Markupai.node.ts
@@ -107,20 +107,6 @@ export class Markupai implements INodeType {
         },
       },
       {
-        displayName: "Org Name",
-        name: "orgName",
-        type: "string",
-        default: "",
-        description: "Organization name injected from context for style checks",
-        displayOptions: {
-          show: {
-            resource: ["agent"],
-            operation: ["runAgent"],
-            agents: STYLE_OPTION_AGENT_IDS,
-          },
-        },
-      },
-      {
         displayName: "Target",
         name: "targetId",
         type: "options",
@@ -131,20 +117,6 @@ export class Markupai implements INodeType {
         typeOptions: {
           loadOptionsMethod: LOAD_STYLE_AGENT_TARGETS,
         },
-        displayOptions: {
-          show: {
-            resource: ["agent"],
-            operation: ["runAgent"],
-            agents: STYLE_OPTION_AGENT_IDS,
-          },
-        },
-      },
-      {
-        displayName: "Content Profile ID",
-        name: "contentProfileId",
-        type: "string",
-        default: "",
-        description: "Language-service content profile ID for style checks",
         displayOptions: {
           show: {
             resource: ["agent"],
@@ -188,14 +160,15 @@ export class Markupai implements INodeType {
             name: "documentName",
             type: "string",
             default: "",
-            description: "Name of the document being analyzed",
+            description: "Human-readable name of the document being analyzed",
           },
           {
-            displayName: "Document URL",
-            name: "documentLink",
+            displayName: "Document Reference",
+            name: "documentRef",
             type: "string",
             default: "",
-            description: "URL or link to the source document",
+            description:
+              "Caller-supplied identifier (for example a CMS page ID) echoed back in the result for tracking",
           },
           {
             displayName: "Timeout (Ms)",

--- a/nodes/Markupai/utils/agent.input.coverage.ts
+++ b/nodes/Markupai/utils/agent.input.coverage.ts
@@ -9,15 +9,9 @@ export const AGENT_IDS = {
   snippetReadiness: "ag_5yM0oN4rStVx",
 } as const;
 
-export type AdditionalOptionField =
-  | "documentName"
-  | "documentLink"
-  | "domainIds"
-  | "orgName"
-  | "targetId"
-  | "contentProfileId";
+export type AdditionalOptionField = "documentName" | "documentRef" | "domainIds" | "targetId";
 
-export const COMMON_OPTION_FIELDS = ["documentName", "documentLink"] as const;
+export const COMMON_OPTION_FIELDS = ["documentName", "documentRef"] as const;
 
 /**
  * Explicit map of non-orchestrator agent input coverage from api.json.
@@ -32,7 +26,7 @@ export const AGENT_ADDITIONAL_OPTION_FIELDS: Readonly<
   [AGENT_IDS.freshness]: [...COMMON_OPTION_FIELDS],
   [AGENT_IDS.focusAgent]: [...COMMON_OPTION_FIELDS],
   [AGENT_IDS.aiVoiceDetector]: [...COMMON_OPTION_FIELDS, "domainIds"],
-  [AGENT_IDS.styleAgent]: [...COMMON_OPTION_FIELDS, "orgName", "targetId", "contentProfileId"],
+  [AGENT_IDS.styleAgent]: [...COMMON_OPTION_FIELDS, "targetId"],
   [AGENT_IDS.snippetReadiness]: [...COMMON_OPTION_FIELDS],
 };
 
@@ -41,7 +35,5 @@ export const DOMAIN_IDS_AGENT_IDS = Object.entries(AGENT_ADDITIONAL_OPTION_FIELD
   .map(([agentId]) => agentId);
 
 export const STYLE_OPTION_AGENT_IDS = Object.entries(AGENT_ADDITIONAL_OPTION_FIELDS)
-  .filter(([, fields]) =>
-    fields.some((field) => ["orgName", "targetId", "contentProfileId"].includes(field)),
-  )
+  .filter(([, fields]) => fields.includes("targetId"))
   .map(([agentId]) => agentId);

--- a/nodes/Markupai/utils/process.item.ts
+++ b/nodes/Markupai/utils/process.item.ts
@@ -18,11 +18,9 @@ import type {
 
 type AdditionalOptions = {
   documentName?: string;
-  documentLink?: string;
+  documentRef?: string;
   domainIds?: string[];
-  orgName?: string;
   targetId?: string;
-  contentProfileId?: string;
   timeout?: number;
 };
 
@@ -40,20 +38,14 @@ function buildRunRequest(
   if (allowedOptionFields.includes("documentName") && additionalOptions.documentName) {
     request.document_name = additionalOptions.documentName;
   }
-  if (allowedOptionFields.includes("documentLink") && additionalOptions.documentLink) {
-    request.url = additionalOptions.documentLink;
+  if (allowedOptionFields.includes("documentRef") && additionalOptions.documentRef) {
+    request.document_ref = additionalOptions.documentRef;
   }
   if (allowedOptionFields.includes("domainIds") && additionalOptions.domainIds?.length) {
     request.domain_ids = additionalOptions.domainIds.filter(Boolean);
   }
-  if (allowedOptionFields.includes("orgName") && additionalOptions.orgName) {
-    request.org_name = additionalOptions.orgName;
-  }
   if (allowedOptionFields.includes("targetId") && additionalOptions.targetId) {
     request.target_id = additionalOptions.targetId;
-  }
-  if (allowedOptionFields.includes("contentProfileId") && additionalOptions.contentProfileId) {
-    request.content_profile_id = additionalOptions.contentProfileId;
   }
 
   return request;
@@ -108,13 +100,15 @@ function createSuccessResponse(
     issue_counts: issueCounts,
   };
 
+  const effectiveDocumentRef = additionalOptions.documentRef ?? response.document_ref ?? null;
+
   const reportData: AgentResult = {
     type: "agent_run",
     timestamp: response.completed_at ?? response.started_at,
     workflow_id: response.workflow_id,
     agent_name: getSelectedAgentName(allAgents, selectedAgentIds),
     document_name: additionalOptions.documentName ?? null,
-    document_url: additionalOptions.documentLink ?? null,
+    document_ref: effectiveDocumentRef,
     result: resultForReport as unknown as AgentResult["result"],
     success: response.status === "completed",
   };
@@ -124,11 +118,11 @@ function createSuccessResponse(
   const json: Record<string, unknown> = {
     workflow_id: response.workflow_id,
     status: response.status,
+    document_ref: effectiveDocumentRef,
     result: response.result,
     started_at: response.started_at,
     completed_at: response.completed_at,
     duration_seconds: response.duration_seconds,
-    error: response.error,
     issue_counts: issueCounts,
     html_report: htmlReport,
   };
@@ -143,11 +137,7 @@ function assertCompletedStatus(response: AgentRunResponse): void {
     return;
   }
 
-  throw new Error(
-    response.error
-      ? `Workflow ${response.status}: ${response.error}`
-      : `Workflow ended with status: ${response.status}`,
-  );
+  throw new Error(`Workflow ended with status: ${response.status}`);
 }
 
 export async function processMarkupaiItem(
@@ -164,17 +154,15 @@ export async function processMarkupaiItem(
 
     const commonOptions = (this.getNodeParameter("additionalOptions", itemIndex) ?? {}) as {
       documentName?: string;
-      documentLink?: string;
+      documentRef?: string;
       timeout?: number;
     };
     const additionalOptions: AdditionalOptions = {
       documentName: commonOptions.documentName,
-      documentLink: commonOptions.documentLink,
+      documentRef: commonOptions.documentRef,
       timeout: commonOptions.timeout,
       domainIds: this.getNodeParameter("domainIds", itemIndex, []) as string[],
-      orgName: this.getNodeParameter("orgName", itemIndex, "") as string,
       targetId: this.getNodeParameter("targetId", itemIndex, "") as string,
-      contentProfileId: this.getNodeParameter("contentProfileId", itemIndex, "") as string,
     };
 
     const body = buildRunRequest.call(this, itemIndex, selectedAgentId, additionalOptions);

--- a/nodes/Markupai/utils/report_template.ts
+++ b/nodes/Markupai/utils/report_template.ts
@@ -55,7 +55,7 @@ export interface AgentResult {
   agent_name: string;
   // Caller-supplied document metadata, surfaced in the Workflow table.
   document_name?: string | null;
-  document_url?: string | null;
+  document_ref?: string | null;
   result: {
     issues: AgentIssue[];
     warnings?: unknown[];
@@ -423,13 +423,15 @@ function renderWorkflowRows(data: AgentResult): string {
   ];
 
   const docName = data.document_name?.trim() ?? "";
-  const docUrl = data.document_url?.trim() ?? "";
-  if (docName || docUrl) {
-    const linkText = esc(docName || docUrl);
-    const docCell = docUrl
-      ? `<a href="${esc(docUrl)}" style="color:${C.coral};text-decoration:none;">${linkText}</a>`
-      : linkText;
-    rows.push(["Document", docCell]);
+  if (docName) {
+    rows.push(["Document", esc(docName)]);
+  }
+  const docRef = data.document_ref?.trim() ?? "";
+  if (docRef) {
+    rows.push([
+      "Reference",
+      `<span style="font-family:Menlo,Consolas,monospace;font-size:11px;color:${C.saddle};word-break:break-all;">${esc(docRef)}</span>`,
+    ]);
   }
 
   rows.push(

--- a/test/nodes/Markupai.node.test.ts
+++ b/test/nodes/Markupai.node.test.ts
@@ -133,9 +133,11 @@ describe("Markupai", () => {
       const propertyNames = properties.map((p) => p.name);
       expect(propertyNames).toContain("additionalOptions");
       expect(propertyNames).toContain("domainIds");
-      expect(propertyNames).toContain("orgName");
       expect(propertyNames).toContain("targetId");
-      expect(propertyNames).toContain("contentProfileId");
+      // Removed in INT-530: org_name and content_profile_id are auto-detected
+      // from the API key; documentLink/Document URL is no longer supported.
+      expect(propertyNames).not.toContain("orgName");
+      expect(propertyNames).not.toContain("contentProfileId");
 
       const targetIdProp = properties.find((p) => p.name === "targetId");
       expect(targetIdProp?.type).toBe("options");
@@ -154,8 +156,9 @@ describe("Markupai", () => {
       const additionalOptions = additionalOptionsProp.options ?? [];
       const additionalOptionNames = additionalOptions.map((o) => o.name);
       expect(additionalOptionNames).toEqual(
-        expect.arrayContaining(["documentName", "documentLink", "timeout"]),
+        expect.arrayContaining(["documentName", "documentRef", "timeout"]),
       );
+      expect(additionalOptionNames).not.toContain("documentLink");
 
       const domainIdsOption = properties.find(
         (o) => o.name === "domainIds" && "type" in o && "typeOptions" in o,

--- a/test/utils/agent.input.coverage.test.ts
+++ b/test/utils/agent.input.coverage.test.ts
@@ -7,20 +7,14 @@ import {
 describe("agent.input.coverage", () => {
   it("maps every non-orchestrator agent from api.json to additional option fields", () => {
     expect(AGENT_ADDITIONAL_OPTION_FIELDS).toEqual({
-      [AGENT_IDS.terminology]: ["documentName", "documentLink", "domainIds"],
-      [AGENT_IDS.genericClaims]: ["documentName", "documentLink"],
-      [AGENT_IDS.sourceAuthority]: ["documentName", "documentLink"],
-      [AGENT_IDS.freshness]: ["documentName", "documentLink"],
-      [AGENT_IDS.focusAgent]: ["documentName", "documentLink"],
-      [AGENT_IDS.aiVoiceDetector]: ["documentName", "documentLink", "domainIds"],
-      [AGENT_IDS.styleAgent]: [
-        "documentName",
-        "documentLink",
-        "orgName",
-        "targetId",
-        "contentProfileId",
-      ],
-      [AGENT_IDS.snippetReadiness]: ["documentName", "documentLink"],
+      [AGENT_IDS.terminology]: ["documentName", "documentRef", "domainIds"],
+      [AGENT_IDS.genericClaims]: ["documentName", "documentRef"],
+      [AGENT_IDS.sourceAuthority]: ["documentName", "documentRef"],
+      [AGENT_IDS.freshness]: ["documentName", "documentRef"],
+      [AGENT_IDS.focusAgent]: ["documentName", "documentRef"],
+      [AGENT_IDS.aiVoiceDetector]: ["documentName", "documentRef", "domainIds"],
+      [AGENT_IDS.styleAgent]: ["documentName", "documentRef", "targetId"],
+      [AGENT_IDS.snippetReadiness]: ["documentName", "documentRef"],
     });
   });
 });

--- a/test/utils/agents.api.utils.test.ts
+++ b/test/utils/agents.api.utils.test.ts
@@ -245,7 +245,6 @@ describe("agents.api.utils", () => {
       const failed = {
         workflow_id: "wf_123",
         status: "failed" as const,
-        error: "Agent error",
         started_at: "2025-01-01T00:00:00Z",
       };
       const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: failed });
@@ -256,7 +255,6 @@ describe("agents.api.utils", () => {
       const result = await pollWorkflowUntilDone.call(mock, "wf_123", 30_000);
 
       expect(result.status).toBe("failed");
-      expect(result.error).toBe("Agent error");
       expect(mockCall).toHaveBeenCalledTimes(1);
     });
 

--- a/test/utils/process.item.test.ts
+++ b/test/utils/process.item.test.ts
@@ -90,14 +90,12 @@ function createGetNodeParameter(additionalOptions: Record<string, unknown> = {})
     if (name === "additionalOptions") {
       return {
         documentName: additionalOptions.documentName ?? "",
-        documentLink: additionalOptions.documentLink ?? "",
+        documentRef: additionalOptions.documentRef ?? "",
         timeout: additionalOptions.timeout ?? 120_000,
       };
     }
     if (name === "domainIds") return additionalOptions.domainIds ?? [];
-    if (name === "orgName") return additionalOptions.orgName ?? "";
     if (name === "targetId") return additionalOptions.targetId ?? "";
-    if (name === "contentProfileId") return additionalOptions.contentProfileId ?? "";
     return undefined;
   });
 }
@@ -277,13 +275,13 @@ describe("process.item", () => {
         });
       });
 
-      it("passes documentName, documentLink, domainIds in request body", async () => {
+      it("passes documentName, documentRef, domainIds in snake_case request body", async () => {
         mockRunAgent.mockResolvedValue(createCompletedResponse());
 
         const mockExecuteFunctions = createMockExecuteFunctions({
           getNodeParameter: createGetNodeParameter({
             documentName: "doc.txt",
-            documentLink: "https://example.com/doc",
+            documentRef: "cms-page-42",
             domainIds: ["d1", "d2"],
           }),
         });
@@ -295,15 +293,14 @@ describe("process.item", () => {
           false,
         );
 
-        expect(mockRunAgent).toHaveBeenCalledWith(
-          "ag_WUijxT0DthMg",
-          expect.objectContaining({
-            text: "test content",
-            document_name: "doc.txt",
-            url: "https://example.com/doc",
-            domain_ids: ["d1", "d2"],
-          }),
-        );
+        const body = mockRunAgent.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).toMatchObject({
+          text: "test content",
+          document_name: "doc.txt",
+          document_ref: "cms-page-42",
+          domain_ids: ["d1", "d2"],
+        });
+        expect(body.url).toBeUndefined();
       });
 
       it("uses selected agent ID directly for runAgent", async () => {
@@ -334,18 +331,16 @@ describe("process.item", () => {
         );
       });
 
-      it("passes style-agent additional inputs in snake_case request body", async () => {
+      it("passes style-agent additional inputs in snake_case and drops auto-detected fields", async () => {
         mockRunAgent.mockResolvedValue(createCompletedResponse());
 
         const mockExecuteFunctions = createMockExecuteFunctions({
           getNodeParameter: vi.fn().mockImplementation((name: string) => {
             if (name === "agents") return "ag_vYCPHsSQnnJj";
             if (name === "content") return "test content";
-            if (name === "additionalOptions") return {};
+            if (name === "additionalOptions") return { documentName: "Style doc" };
             if (name === "domainIds") return [];
-            if (name === "orgName") return "Markup AI";
             if (name === "targetId") return "target_123";
-            if (name === "contentProfileId") return "profile_456";
             return undefined;
           }),
         });
@@ -357,15 +352,16 @@ describe("process.item", () => {
           false,
         );
 
-        expect(mockRunAgent).toHaveBeenCalledWith(
-          "ag_vYCPHsSQnnJj",
-          expect.objectContaining({
-            text: "test content",
-            org_name: "Markup AI",
-            target_id: "target_123",
-            content_profile_id: "profile_456",
-          }),
-        );
+        const body = mockRunAgent.mock.calls[0][1] as Record<string, unknown>;
+        expect(body).toMatchObject({
+          text: "test content",
+          document_name: "Style doc",
+          target_id: "target_123",
+        });
+        // Auto-detected fields are never sent to the API.
+        expect(body.org_name).toBeUndefined();
+        expect(body.content_profile_id).toBeUndefined();
+        expect(body.url).toBeUndefined();
       });
 
       it("does not pass unsupported agent-specific options for non-style agents", async () => {
@@ -373,9 +369,7 @@ describe("process.item", () => {
 
         const mockExecuteFunctions = createMockExecuteFunctions({
           getNodeParameter: createGetNodeParameter({
-            orgName: "Markup AI",
             targetId: "target_123",
-            contentProfileId: "profile_456",
           }),
         });
 
@@ -388,11 +382,7 @@ describe("process.item", () => {
 
         expect(mockRunAgent).toHaveBeenCalledWith(
           "ag_WUijxT0DthMg",
-          expect.not.objectContaining({
-            org_name: "Markup AI",
-            target_id: "target_123",
-            content_profile_id: "profile_456",
-          }),
+          expect.not.objectContaining({ target_id: "target_123" }),
         );
       });
 
@@ -419,7 +409,6 @@ describe("process.item", () => {
         mockRunAgent.mockResolvedValue(
           createAgentRunResponse({
             status: "failed",
-            error: "Policy check failed",
           }),
         );
 

--- a/test/utils/report_template.test.ts
+++ b/test/utils/report_template.test.ts
@@ -9,7 +9,7 @@ describe("renderReport", () => {
       workflow_id: "agw_L2Jjla1S6MftldxZo2AeNuWq",
       agent_name: "style_agent",
       document_name: "Pricing page",
-      document_url: "https://example.com/pricing",
+      document_ref: "cms-pricing-page-42",
       result: {
         issues: [
           {
@@ -52,8 +52,10 @@ describe("renderReport", () => {
     expect(html).toContain("Use a less colloquial word?");
     expect(html).toContain("Flesch-Kincaid grade level: 2");
     expect(html).toContain("Pricing page");
-    // The document name is rendered as a hyperlink when document_url is present.
-    expect(html).toContain('href="https://example.com/pricing"');
+    // Document name renders as plain text; the reference renders in a separate
+    // monospace row.
+    expect(html).toContain("cms-pricing-page-42");
+    expect(html).not.toContain('href="https://example.com/pricing"');
     // Non-numeric mode hides per-goal scores and analysis index rows.
     expect(html).not.toContain("Scores by goal");
     expect(html).not.toContain("Clarity index");


### PR DESCRIPTION
## Summary

Mirror zapier's [INT-527](https://markup-ai.atlassian.net/browse/INT-527) / [zapier-app#227](https://github.com/markupai/zapier-app/pull/227) in n8n. Third and final PR aligning n8n with the latest Markup AI agentic API surface. Blocked by [INT-529](https://markup-ai.atlassian.net/browse/INT-529) (merged).

- **Types**: add `document_ref` + `request_id` to `AgentRunResponse`; remove `error` (not in the OpenAPI spec); add `document_ref` to `AgentRunRequest`.
- **Inputs** (in `Markupai.node.ts`): drop `Org Name`, `Content Profile ID`, and `Document URL`. The first two are auto-detected from the API key per the new contract; the URL field is replaced with `Document Reference` (key `documentRef`) so input keys match the wire schema exactly.
- **Per-agent allowlist** (`agent.input.coverage.ts`): the style agent allowlist is now `[documentName, documentRef, targetId]`. `COMMON_OPTION_FIELDS` becomes `[documentName, documentRef]`.
- **Wire body**: `process.item.ts` forwards `documentRef` → `body.document_ref`; no longer sends `url`, `org_name`, or `content_profile_id`.
- **Output envelope**: stops reading `response.error` (field is gone from the spec). Adds `document_ref` to the JSON output. Failure messages use only `status`.
- **Report renderer**: switches the `AgentResult.document_url` field to `document_ref`. `renderWorkflowRows` now shows plain-text `Document` (no hyperlink) and an additional `Reference` row in monospace when set — matches the post-INT-527 zapier shape.

JIRA: [INT-530](https://markup-ai.atlassian.net/browse/INT-530)

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npm run type-check`
- [x] `npm test` — 79/79 pass (updated allowlist, body assertions, descriptor expectations, report renderer)
- [x] `npm run build` — gulp + tsc clean
- [ ] Manual: load the node in n8n, confirm `Org Name` / `Content Profile ID` / `Document URL` are gone, the new `Document Reference` field is under Additional Options, and an end-to-end run echoes `document_ref` in the JSON output.

## Breaking change note

For users with existing n8n workflows: any workflow that explicitly set `Org Name`, `Content Profile ID`, or `Document URL` will silently lose those values on save. Document this in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INT-527]: https://markup-ai.atlassian.net/browse/INT-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-529]: https://markup-ai.atlassian.net/browse/INT-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-530]: https://markup-ai.atlassian.net/browse/INT-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ