### PR TITLE
refactor: INT-588 migrate off deprecated style-agent target API to style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ To use this node, you'll need a Markup AI API account.
 
 The **Run Agent** operation supports the following configuration:
 
-| Option                                      | Type               | Required | Default  | Description                                                                                                |
-| ------------------------------------------- | ------------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| **Agent**                                   | Single-select      | Yes      | -        | Select the agent to run. Currently only `style_agent` is exposed.                                          |
-| **Target**                                  | Single-select      | No       | -        | Style agent target (style guide). Loaded from `GET /style-agent/targets`. Defaults to your default target. |
-| **Content**                                 | String (multiline) | Yes      | -        | Document text to analyze.                                                                                  |
-| **Additional Options → Document Name**      | String             | No       | `""`     | Human-readable name of the document being analyzed.                                                        |
-| **Additional Options → Document Reference** | String             | No       | `""`     | Caller-supplied identifier (e.g. CMS page ID) echoed back in the result for tracking.                      |
-| **Additional Options → Timeout (Ms)**       | Number             | No       | `120000` | Maximum time to wait while polling workflow status before returning a timeout error.                       |
+| Option                                      | Type               | Required | Default  | Description                                                                                                 |
+| ------------------------------------------- | ------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| **Agent**                                   | Single-select      | Yes      | -        | Select the agent to run. Currently only `style_agent` is exposed.                                           |
+| **Style Guide**                             | Single-select      | No       | -        | Style agent style guide. Loaded from `GET /style-agent/style-guides`. Defaults to your default style guide. |
+| **Content**                                 | String (multiline) | Yes      | -        | Document text to analyze.                                                                                   |
+| **Additional Options → Document Name**      | String             | No       | `""`     | Human-readable name of the document being analyzed.                                                         |
+| **Additional Options → Document Reference** | String             | No       | `""`     | Caller-supplied identifier (e.g. CMS page ID) echoed back in the result for tracking.                       |
+| **Additional Options → Timeout (Ms)**       | Number             | No       | `120000` | Maximum time to wait while polling workflow status before returning a timeout error.                        |
 
 Organization and content profile are auto-detected from the API key — there is no input for them.
 

--- a/nodes/Markupai/Markupai.api.types.ts
+++ b/nodes/Markupai/Markupai.api.types.ts
@@ -52,7 +52,7 @@ export interface AgentRunRequest {
   url?: string | null;
   document_name?: string | null;
   document_ref?: string | null;
-  target_id?: string | null;
+  style_guide_id?: string | null;
   webhook_url?: string | null;
 }
 
@@ -82,7 +82,7 @@ export interface OrganizationConfigResponse {
   style_agent_numeric_scoring: boolean;
 }
 
-export interface StyleAgentTarget {
+export interface StyleGuide {
   id: string;
   display_name: string;
   is_default: boolean;

--- a/nodes/Markupai/Markupai.node.ts
+++ b/nodes/Markupai/Markupai.node.ts
@@ -11,13 +11,13 @@ import { MARKUPAI_API_CREDENTIAL_NAME } from "../../credentials/MarkupAiApi.cred
 import { listAllAgents } from "./utils/agents.api.utils";
 import { DOMAIN_IDS_AGENT_IDS, STYLE_OPTION_AGENT_IDS } from "./utils/agent.input.coverage";
 import { createErrorResponse, getErrorDescription } from "./utils/error.helpers";
-import { loadAgents, loadStyleAgentTargets, loadTerminologyDomains } from "./utils/load.options";
+import { loadAgents, loadStyleGuides, loadTerminologyDomains } from "./utils/load.options";
 import { processMarkupaiItem } from "./utils/process.item";
 import { assertStyleAgentEnabled, getStyleAgentConfig } from "./utils/style_agent_api";
 
 const LOAD_AGENTS = "loadAgents" as const;
 const LOAD_TERMINOLOGY_DOMAINS = "loadTerminologyDomains" as const;
-const LOAD_STYLE_AGENT_TARGETS = "loadStyleAgentTargets" as const;
+const LOAD_STYLE_GUIDES = "loadStyleGuides" as const;
 
 export class Markupai implements INodeType {
   description: INodeTypeDescription = {
@@ -112,15 +112,15 @@ export class Markupai implements INodeType {
         },
       },
       {
-        displayName: "Target",
-        name: "targetId",
+        displayName: "Style Guide",
+        name: "styleGuideId",
         type: "options",
         options: [],
         default: "",
         description:
-          "Configured style agent target. Content profile is auto-detected by Markup AI.",
+          "Configured style agent style guide. Content profile is auto-detected by Markup AI.",
         typeOptions: {
-          loadOptionsMethod: LOAD_STYLE_AGENT_TARGETS,
+          loadOptionsMethod: LOAD_STYLE_GUIDES,
         },
         displayOptions: {
           show: {
@@ -191,7 +191,7 @@ export class Markupai implements INodeType {
     loadOptions: {
       [LOAD_AGENTS]: loadAgents,
       [LOAD_TERMINOLOGY_DOMAINS]: loadTerminologyDomains,
-      [LOAD_STYLE_AGENT_TARGETS]: loadStyleAgentTargets,
+      [LOAD_STYLE_GUIDES]: loadStyleGuides,
     },
   };
 

--- a/nodes/Markupai/utils/agent.input.coverage.ts
+++ b/nodes/Markupai/utils/agent.input.coverage.ts
@@ -9,7 +9,7 @@ export const AGENT_IDS = {
   snippetReadiness: "ag_5yM0oN4rStVx",
 } as const;
 
-export type AdditionalOptionField = "documentName" | "documentRef" | "domainIds" | "targetId";
+export type AdditionalOptionField = "documentName" | "documentRef" | "domainIds" | "styleGuideId";
 
 export const COMMON_OPTION_FIELDS = ["documentName", "documentRef"] as const;
 
@@ -26,7 +26,7 @@ export const AGENT_ADDITIONAL_OPTION_FIELDS: Readonly<
   [AGENT_IDS.freshness]: [...COMMON_OPTION_FIELDS],
   [AGENT_IDS.focusAgent]: [...COMMON_OPTION_FIELDS],
   [AGENT_IDS.aiVoiceDetector]: [...COMMON_OPTION_FIELDS, "domainIds"],
-  [AGENT_IDS.styleAgent]: [...COMMON_OPTION_FIELDS, "targetId"],
+  [AGENT_IDS.styleAgent]: [...COMMON_OPTION_FIELDS, "styleGuideId"],
   [AGENT_IDS.snippetReadiness]: [...COMMON_OPTION_FIELDS],
 };
 
@@ -35,5 +35,5 @@ export const DOMAIN_IDS_AGENT_IDS = Object.entries(AGENT_ADDITIONAL_OPTION_FIELD
   .map(([agentId]) => agentId);
 
 export const STYLE_OPTION_AGENT_IDS = Object.entries(AGENT_ADDITIONAL_OPTION_FIELDS)
-  .filter(([, fields]) => fields.includes("targetId"))
+  .filter(([, fields]) => fields.includes("styleGuideId"))
   .map(([agentId]) => agentId);

--- a/nodes/Markupai/utils/load.options.ts
+++ b/nodes/Markupai/utils/load.options.ts
@@ -4,7 +4,7 @@ import type {
   INodePropertyOptions,
 } from "n8n-workflow";
 import { getBaseUrlString } from "../../../utils/common.utils";
-import { listStyleAgentTargets } from "./style_agent_api";
+import { listStyleGuides } from "./style_agent_api";
 import { assertOk } from "./api.errors";
 import type {
   AgentListResult,
@@ -123,19 +123,19 @@ export async function loadTerminologyDomains(
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function loadStyleAgentTargets(
+export async function loadStyleGuides(
   this: ILoadOptionsFunctions,
 ): Promise<INodePropertyOptions[]> {
-  const targets = await listStyleAgentTargets.call(this);
+  const styleGuides = await listStyleGuides.call(this);
 
-  return targets
-    .map((target) => ({
-      name: target.display_name,
-      value: target.id,
+  return styleGuides
+    .map((styleGuide) => ({
+      name: styleGuide.display_name,
+      value: styleGuide.id,
     }))
     .sort((a, b) => {
-      const aIsDefault = targets.find((t) => t.id === a.value)?.is_default ?? false;
-      const bIsDefault = targets.find((t) => t.id === b.value)?.is_default ?? false;
+      const aIsDefault = styleGuides.find((sg) => sg.id === a.value)?.is_default ?? false;
+      const bIsDefault = styleGuides.find((sg) => sg.id === b.value)?.is_default ?? false;
       if (aIsDefault && !bIsDefault) return -1;
       if (!aIsDefault && bIsDefault) return 1;
       return a.name.localeCompare(b.name);

--- a/nodes/Markupai/utils/process.item.ts
+++ b/nodes/Markupai/utils/process.item.ts
@@ -14,7 +14,7 @@ type AdditionalOptions = {
   documentName?: string;
   documentRef?: string;
   domainIds?: string[];
-  targetId?: string;
+  styleGuideId?: string;
   timeout?: number;
 };
 
@@ -38,8 +38,8 @@ function buildRunRequest(
   if (allowedOptionFields.includes("domainIds") && additionalOptions.domainIds?.length) {
     request.domain_ids = additionalOptions.domainIds.filter(Boolean);
   }
-  if (allowedOptionFields.includes("targetId") && additionalOptions.targetId) {
-    request.target_id = additionalOptions.targetId;
+  if (allowedOptionFields.includes("styleGuideId") && additionalOptions.styleGuideId) {
+    request.style_guide_id = additionalOptions.styleGuideId;
   }
 
   return request;
@@ -134,7 +134,7 @@ export async function processMarkupaiItem(
     documentRef: commonOptions.documentRef,
     timeout: commonOptions.timeout,
     domainIds: this.getNodeParameter("domainIds", itemIndex, []) as string[],
-    targetId: this.getNodeParameter("targetId", itemIndex, "") as string,
+    styleGuideId: this.getNodeParameter("styleGuideId", itemIndex, "") as string,
   };
 
   const body = buildRunRequest.call(this, itemIndex, selectedAgentId, additionalOptions);

--- a/nodes/Markupai/utils/report_template.ts
+++ b/nodes/Markupai/utils/report_template.ts
@@ -60,8 +60,8 @@ export interface AgentResult {
     issues: AgentIssue[];
     warnings?: unknown[];
     // `quality` and `analysis` are nullable in the Cortex agent schema;
-    // for style_agent they're only populated when target_id /
-    // content_profile_id resolve a Language-Service target. Every field
+    // for style_agent they're only populated when style_guide_id /
+    // content_profile_id resolve a Language-Service style guide. Every field
     // inside `analysis` is independently nullable.
     quality?: {
       score?: number | null;
@@ -69,6 +69,12 @@ export interface AgentResult {
       scoresByGoal?: GoalScore[] | null;
     } | null;
     analysis?: {
+      // The API returns both the new style-guide fields and the legacy target
+      // fields during the migration transition; the renderer prefers the
+      // former and falls back to the latter (`targetId` / `targetDisplayName`
+      // are deprecated and read only as a transition-period fallback).
+      styleGuideId?: string | null;
+      styleGuideDisplayName?: string | null;
       targetId?: string | null;
       targetDisplayName?: string | null;
       contentProfileId?: string | null;
@@ -257,7 +263,10 @@ function renderDocumentSection(
 ): string {
   if (!a) return "";
   const rows: [string, string][] = [];
-  if (a.targetDisplayName) rows.push(["Target", esc(a.targetDisplayName)]);
+  // Prefer the new style-guide field; fall back to the deprecated target field
+  // while the API still returns both during the migration transition.
+  const styleGuideDisplayName = a.styleGuideDisplayName ?? a.targetDisplayName;
+  if (styleGuideDisplayName) rows.push(["Style Guide", esc(styleGuideDisplayName)]);
   if (a.contentProfileDisplayName) rows.push(["Content profile", esc(a.contentProfileDisplayName)]);
   if (typeof a.words === "number" && typeof a.sentences === "number") {
     rows.push([

--- a/nodes/Markupai/utils/style_agent_api.ts
+++ b/nodes/Markupai/utils/style_agent_api.ts
@@ -1,10 +1,10 @@
 import type { IExecuteFunctions, IHttpRequestOptions, ILoadOptionsFunctions } from "n8n-workflow";
 import { getBaseUrl } from "./load.options";
 import { assertOk } from "./api.errors";
-import type { OrganizationConfigResponse, StyleAgentTarget } from "../Markupai.api.types";
+import type { OrganizationConfigResponse, StyleGuide } from "../Markupai.api.types";
 
 const CONFIG_PATH = "style-agent/config";
-const TARGETS_PATH = "style-agent/targets";
+const STYLE_GUIDES_PATH = "style-agent/style-guides";
 
 export const STYLE_AGENT_DISABLED_MESSAGE =
   "Style Agent is not enabled for your organization. Contact Markup AI support to enable it.";
@@ -50,10 +50,8 @@ export function assertStyleAgentEnabled(config: OrganizationConfigResponse): voi
   }
 }
 
-export async function listStyleAgentTargets(
-  this: StyleAgentApiContext,
-): Promise<StyleAgentTarget[]> {
-  const targets = await getJson<StyleAgentTarget[] | null>(this, TARGETS_PATH);
-  if (!Array.isArray(targets)) return [];
-  return targets.filter((target) => target.enabled);
+export async function listStyleGuides(this: StyleAgentApiContext): Promise<StyleGuide[]> {
+  const styleGuides = await getJson<StyleGuide[] | null>(this, STYLE_GUIDES_PATH);
+  if (!Array.isArray(styleGuides)) return [];
+  return styleGuides.filter((styleGuide) => styleGuide.enabled);
 }

--- a/test/nodes/Markupai.node.test.ts
+++ b/test/nodes/Markupai.node.test.ts
@@ -25,7 +25,7 @@ vi.mock("n8n-workflow", async () => {
 vi.mock("../../nodes/Markupai/utils/load.options", () => ({
   loadAgents: vi.fn(),
   loadTerminologyDomains: vi.fn(),
-  loadStyleAgentTargets: vi.fn(),
+  loadStyleGuides: vi.fn(),
 }));
 
 vi.mock("../../nodes/Markupai/utils/agents.api.utils", () => ({
@@ -133,15 +133,17 @@ describe("Markupai", () => {
       const propertyNames = properties.map((p) => p.name);
       expect(propertyNames).toContain("additionalOptions");
       expect(propertyNames).toContain("domainIds");
-      expect(propertyNames).toContain("targetId");
+      expect(propertyNames).toContain("styleGuideId");
       // Removed in INT-530: org_name and content_profile_id are auto-detected
       // from the API key; documentLink/Document URL is no longer supported.
       expect(propertyNames).not.toContain("orgName");
       expect(propertyNames).not.toContain("contentProfileId");
+      // Migrated in INT-588 from the deprecated target API to style guide.
+      expect(propertyNames).not.toContain("targetId");
 
-      const targetIdProp = properties.find((p) => p.name === "targetId");
-      expect(targetIdProp?.type).toBe("options");
-      expect(targetIdProp?.typeOptions?.loadOptionsMethod).toBe("loadStyleAgentTargets");
+      const styleGuideIdProp = properties.find((p) => p.name === "styleGuideId");
+      expect(styleGuideIdProp?.type).toBe("options");
+      expect(styleGuideIdProp?.typeOptions?.loadOptionsMethod).toBe("loadStyleGuides");
 
       const additionalOptionsProp = properties.find((p) => p.name === "additionalOptions");
       expect(additionalOptionsProp).toBeDefined();
@@ -183,10 +185,10 @@ describe("Markupai", () => {
   });
 
   describe("Methods", () => {
-    it("should have loadAgents, loadTerminologyDomains, and loadStyleAgentTargets in loadOptions", () => {
+    it("should have loadAgents, loadTerminologyDomains, and loadStyleGuides in loadOptions", () => {
       expect(markupai.methods.loadOptions.loadAgents).toBeDefined();
       expect(markupai.methods.loadOptions.loadTerminologyDomains).toBeDefined();
-      expect(markupai.methods.loadOptions.loadStyleAgentTargets).toBeDefined();
+      expect(markupai.methods.loadOptions.loadStyleGuides).toBeDefined();
     });
   });
 

--- a/test/utils/agent.input.coverage.test.ts
+++ b/test/utils/agent.input.coverage.test.ts
@@ -13,7 +13,7 @@ describe("agent.input.coverage", () => {
       [AGENT_IDS.freshness]: ["documentName", "documentRef"],
       [AGENT_IDS.focusAgent]: ["documentName", "documentRef"],
       [AGENT_IDS.aiVoiceDetector]: ["documentName", "documentRef", "domainIds"],
-      [AGENT_IDS.styleAgent]: ["documentName", "documentRef", "targetId"],
+      [AGENT_IDS.styleAgent]: ["documentName", "documentRef", "styleGuideId"],
       [AGENT_IDS.snippetReadiness]: ["documentName", "documentRef"],
     });
   });

--- a/test/utils/load.options.test.ts
+++ b/test/utils/load.options.test.ts
@@ -4,7 +4,7 @@ import type { ILoadOptionsFunctions, INode } from "n8n-workflow";
 import {
   getBaseUrl,
   loadAgents,
-  loadStyleAgentTargets,
+  loadStyleGuides,
   loadTerminologyDomains,
 } from "../../nodes/Markupai/utils/load.options";
 
@@ -244,37 +244,63 @@ describe("load.options", () => {
     });
   });
 
-  describe("loadStyleAgentTargets", () => {
-    const targetsResponse = [
-      { id: "tgt_main", display_name: "Main", is_default: true, enabled: true },
-      { id: "tgt_marketing", display_name: "Marketing", is_default: false, enabled: true },
-      { id: "tgt_dev", display_name: "Dev", is_default: false, enabled: true },
-      { id: "tgt_disabled", display_name: "Disabled SG", is_default: false, enabled: false },
+  describe("loadStyleGuides", () => {
+    const styleGuidesResponse = [
+      { id: "sg_main", display_name: "Main", is_default: true, enabled: true },
+      { id: "sg_marketing", display_name: "Marketing", is_default: false, enabled: true },
+      { id: "sg_dev", display_name: "Dev", is_default: false, enabled: true },
+      { id: "sg_disabled", display_name: "Disabled SG", is_default: false, enabled: false },
     ];
 
-    it("returns enabled targets with default first, then alphabetical", async () => {
+    it("returns enabled style guides with default first, then alphabetical", async () => {
       const loadOptionsFunction = createMockLoadOptionsFunctions({
         getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
         helpers: {
           httpRequestWithAuthentication: {
             call: vi.fn().mockResolvedValue({
-              body: targetsResponse,
+              body: styleGuidesResponse,
               statusCode: 200,
             }),
           },
         },
       });
 
-      const result = await loadStyleAgentTargets.call(loadOptionsFunction);
+      const result = await loadStyleGuides.call(loadOptionsFunction);
 
       expect(result).toEqual([
-        { name: "Main", value: "tgt_main" },
-        { name: "Dev", value: "tgt_dev" },
-        { name: "Marketing", value: "tgt_marketing" },
+        { name: "Main", value: "sg_main" },
+        { name: "Dev", value: "sg_dev" },
+        { name: "Marketing", value: "sg_marketing" },
       ]);
     });
 
-    it("throws a NodeApiError when the targets API returns an error status", async () => {
+    it("calls the style-guides endpoint with the production base URL", async () => {
+      const mockCall = vi.fn().mockResolvedValue({
+        body: styleGuidesResponse,
+        statusCode: 200,
+      });
+
+      const loadOptionsFunction = createMockLoadOptionsFunctions({
+        getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
+        helpers: {
+          httpRequestWithAuthentication: {
+            call: mockCall,
+          },
+        },
+      });
+
+      await loadStyleGuides.call(loadOptionsFunction);
+
+      expect(mockCall).toHaveBeenCalledWith(
+        loadOptionsFunction,
+        "markupaiApi",
+        expect.objectContaining({
+          url: "https://api.markup.ai/style-agent/style-guides",
+        }),
+      );
+    });
+
+    it("throws a NodeApiError when the style-guides API returns an error status", async () => {
       const loadOptionsFunction = createMockLoadOptionsFunctions({
         getCredentials: vi.fn().mockResolvedValue({ apiKey: "mocked-key" }),
         helpers: {
@@ -287,7 +313,7 @@ describe("load.options", () => {
         },
       });
 
-      const promise = loadStyleAgentTargets.call(loadOptionsFunction);
+      const promise = loadStyleGuides.call(loadOptionsFunction);
       await expect(promise).rejects.toBeInstanceOf(NodeApiError);
       await expect(promise).rejects.toMatchObject({ httpCode: "403" });
     });

--- a/test/utils/process.item.test.ts
+++ b/test/utils/process.item.test.ts
@@ -61,7 +61,7 @@ function createGetNodeParameter(additionalOptions: Record<string, unknown> = {})
       };
     }
     if (name === "domainIds") return additionalOptions.domainIds ?? [];
-    if (name === "targetId") return additionalOptions.targetId ?? "";
+    if (name === "styleGuideId") return additionalOptions.styleGuideId ?? "";
     return undefined;
   });
 }
@@ -306,7 +306,7 @@ describe("process.item", () => {
             if (name === "content") return "test content";
             if (name === "additionalOptions") return { documentName: "Style doc" };
             if (name === "domainIds") return [];
-            if (name === "targetId") return "target_123";
+            if (name === "styleGuideId") return "sg_123";
             return undefined;
           }),
         });
@@ -322,7 +322,7 @@ describe("process.item", () => {
         expect(body).toMatchObject({
           text: "test content",
           document_name: "Style doc",
-          target_id: "target_123",
+          style_guide_id: "sg_123",
         });
         // Auto-detected fields are never sent to the API.
         expect(body.org_name).toBeUndefined();
@@ -335,7 +335,7 @@ describe("process.item", () => {
 
         const mockExecuteFunctions = createMockExecuteFunctions({
           getNodeParameter: createGetNodeParameter({
-            targetId: "target_123",
+            styleGuideId: "sg_123",
           }),
         });
 
@@ -348,7 +348,7 @@ describe("process.item", () => {
 
         expect(mockRunAgent).toHaveBeenCalledWith(
           "ag_WUijxT0DthMg",
-          expect.not.objectContaining({ target_id: "target_123" }),
+          expect.not.objectContaining({ style_guide_id: "sg_123" }),
         );
       });
 

--- a/test/utils/report_template.test.ts
+++ b/test/utils/report_template.test.ts
@@ -80,7 +80,7 @@ describe("renderReport", () => {
           ],
         },
         analysis: {
-          targetDisplayName: "Main",
+          styleGuideDisplayName: "Main",
           contentProfileDisplayName: "Marketing",
           words: 100,
           sentences: 8,
@@ -100,6 +100,53 @@ describe("renderReport", () => {
     expect(html).toContain("Scores by goal");
     expect(html).toContain("Clarity index");
     expect(html).toContain("Flesch reading ease");
+    // Style-guide display name renders under the new "Style Guide" row label.
+    expect(html).toContain("Style Guide");
+    expect(html).toContain("Main");
+  });
+
+  it("prefers styleGuideDisplayName over the deprecated targetDisplayName", () => {
+    const data: AgentResult = {
+      type: "agent_run",
+      timestamp: "2026-05-18T12:00:00.000Z",
+      workflow_id: "agw_sg_pref",
+      agent_name: "style_agent",
+      result: {
+        issues: [],
+        analysis: {
+          styleGuideDisplayName: "New Style Guide",
+          targetDisplayName: "Legacy Target",
+        },
+      },
+      success: true,
+    };
+
+    const html = renderReport(data, { showNumericScores: true });
+
+    expect(html).toContain("Style Guide");
+    expect(html).toContain("New Style Guide");
+    expect(html).not.toContain("Legacy Target");
+  });
+
+  it("falls back to the deprecated targetDisplayName when styleGuideDisplayName is absent", () => {
+    const data: AgentResult = {
+      type: "agent_run",
+      timestamp: "2026-05-18T12:00:00.000Z",
+      workflow_id: "agw_sg_fallback",
+      agent_name: "style_agent",
+      result: {
+        issues: [],
+        analysis: {
+          targetDisplayName: "Legacy Target",
+        },
+      },
+      success: true,
+    };
+
+    const html = renderReport(data, { showNumericScores: true });
+
+    expect(html).toContain("Style Guide");
+    expect(html).toContain("Legacy Target");
   });
 
   it("renders a sane report when the API payload is missing issues/quality/analysis", () => {

--- a/test/utils/style_agent_api.test.ts
+++ b/test/utils/style_agent_api.test.ts
@@ -4,12 +4,12 @@ import type { ILoadOptionsFunctions, INode } from "n8n-workflow";
 import {
   assertStyleAgentEnabled,
   getStyleAgentConfig,
-  listStyleAgentTargets,
+  listStyleGuides,
   STYLE_AGENT_DISABLED_MESSAGE,
 } from "../../nodes/Markupai/utils/style_agent_api";
 import type {
   OrganizationConfigResponse,
-  StyleAgentTarget,
+  StyleGuide,
 } from "../../nodes/Markupai/Markupai.api.types";
 
 function stubNode(): INode {
@@ -103,26 +103,42 @@ describe("style_agent_api", () => {
     });
   });
 
-  describe("listStyleAgentTargets", () => {
-    it("returns only enabled targets, parsed as an array", async () => {
-      const apiTargets: StyleAgentTarget[] = [
-        { id: "tgt_1", display_name: "Main", is_default: true, enabled: true },
-        { id: "tgt_2", display_name: "Disabled SG", is_default: false, enabled: false },
-        { id: "tgt_3", display_name: "Marketing", is_default: false, enabled: true },
+  describe("listStyleGuides", () => {
+    it("returns only enabled style guides, parsed as an array", async () => {
+      const apiStyleGuides: StyleGuide[] = [
+        { id: "sg_1", display_name: "Main", is_default: true, enabled: true },
+        { id: "sg_2", display_name: "Disabled SG", is_default: false, enabled: false },
+        { id: "sg_3", display_name: "Marketing", is_default: false, enabled: true },
       ];
-      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: apiTargets });
+      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: apiStyleGuides });
       const ctx = createMockContext(mockCall);
 
-      const result = await listStyleAgentTargets.call(ctx);
+      const result = await listStyleGuides.call(ctx);
 
-      expect(result.map((t) => t.id)).toEqual(["tgt_1", "tgt_3"]);
+      expect(result.map((sg) => sg.id)).toEqual(["sg_1", "sg_3"]);
+    });
+
+    it("calls the style-guides endpoint", async () => {
+      const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: [] });
+      const ctx = createMockContext(mockCall);
+
+      await listStyleGuides.call(ctx);
+
+      expect(mockCall).toHaveBeenCalledWith(
+        ctx,
+        "markupaiApi",
+        expect.objectContaining({
+          method: "GET",
+          url: "https://api.markup.ai/style-agent/style-guides",
+        }),
+      );
     });
 
     it("returns empty array when API returns null body", async () => {
       const mockCall = vi.fn().mockResolvedValue({ statusCode: 200, body: null });
       const ctx = createMockContext(mockCall);
 
-      const result = await listStyleAgentTargets.call(ctx);
+      const result = await listStyleGuides.call(ctx);
 
       expect(result).toEqual([]);
     });
@@ -133,7 +149,7 @@ describe("style_agent_api", () => {
         .mockResolvedValue({ statusCode: 403, body: { detail: "forbidden" } });
       const ctx = createMockContext(mockCall);
 
-      const promise = listStyleAgentTargets.call(ctx);
+      const promise = listStyleGuides.call(ctx);
       await expect(promise).rejects.toBeInstanceOf(NodeApiError);
       await expect(promise).rejects.toMatchObject({ httpCode: "403" });
     });


### PR DESCRIPTION
## Summary

Migrates the Markup AI n8n community node off the deprecated Style Agent **target** API to the **style guide** API. Behaviour is otherwise unchanged — this is a rename + endpoint switch.

- **List endpoint:** `GET style-agent/targets` → `GET style-agent/style-guides`
- **Run body wire field:** `target_id` → `style_guide_id`
- **Report analysis:** prefer `styleGuideId` / `styleGuideDisplayName`, fall back to the deprecated `targetId` / `targetDisplayName` (the API returns both during the transition)
- **Renames:** `listStyleAgentTargets` → `listStyleGuides`, `loadStyleAgentTargets` → `loadStyleGuides`, `StyleAgentTarget` → `StyleGuide`; node property `targetId` → `styleGuideId` with label `Target` → `Style Guide`; report row `Target` → `Style Guide`
- Unrelated `target` usages (e.g. `tsconfig` build `target`) were left untouched
- README config table and all affected tests updated

### Prod confirmation
Verified against the prod OpenAPI spec (`api.markup.ai/docs/openapi.json`): `GET /style-agent/style-guides` exists, `GET /style-agent/targets` is **deprecated**, and `POST /style-agent/run` accepts `style_guide_id` (legacy `target_id` has been removed from the prod run schema). The full switch to `style_guide_id` is safe on prod.

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint:check` — pass
- [x] `npm run lint:n8n` — pass
- [x] `npm run type-check` — pass
- [x] `npm run test` — 89 passed (11 files)
- [x] `npm run build` — pass

Jira: [INT-588](https://markup-ai.atlassian.net/browse/INT-588)

[INT-588]: https://markup-ai.atlassian.net/browse/INT-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ